### PR TITLE
Bold Parameter in color method

### DIFF
--- a/lib/graphiti.rb
+++ b/lib/graphiti.rb
@@ -83,7 +83,7 @@ module Graphiti
   end
 
   def self.log(msg, color = :white, bold = false)
-    colored = ActiveSupport::LogSubscriber.new.send(:color, msg, color, bold)
+    colored = ActiveSupport::LogSubscriber.new.send(:color, msg, color, bold: bold)
     logger.debug(colored)
   end
 


### PR DESCRIPTION
Fixes issue where bold parameter was not being passed correctly to color method in ActiveSupport::LogSubscriber.