### PR TITLE
Update ActiveRecord adapter w/ support for Rails 7.2+

### DIFF
--- a/lib/graphiti/adapters/active_record.rb
+++ b/lib/graphiti/adapters/active_record.rb
@@ -298,7 +298,11 @@ module Graphiti
       end
 
       def close
-        ::ActiveRecord::Base.clear_active_connections!
+        if ::ActiveRecord.version > Gem::Version.new("7.1")
+          ::ActiveRecord::Base.connection_handler.clear_active_connections!
+        else
+          ::ActiveRecord::Base.clear_active_connections!
+        end
       end
 
       private

--- a/lib/graphiti/version.rb
+++ b/lib/graphiti/version.rb
@@ -1,3 +1,3 @@
 module Graphiti
-  VERSION = "1.2.36"
+  VERSION = "1.2.37"
 end


### PR DESCRIPTION
In ActiveRecord 7.2 the `clear_active_connections` was (re)moved to the `connection_handler` property.